### PR TITLE
Option to heal inner line breaks

### DIFF
--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -590,6 +590,8 @@
     "    else:\n",
     "        headlines = soup.find_all(source[\"tag\"])\n",
     "        headlines = [headline.get_text() for headline in headlines]\n",
+    "    if \"heal_inner_n\" in source: # When there's a \\n in the middle of a headline, format as SUBHEAD: HEADLINE\n",
+    "        headlines = [headline.strip(\"\\n\").replace(\"\\n\", \": \") for headline in headlines]\n",
     "    if \"min_words\" in source:\n",
     "        headlines = [headline for headline in headlines if count_words(headline)>=source[\"min_words\"]] # Have seen some that are just \"Advertisement\", or author names\n",
     "    headlines = list(set(headlines)) # De-dup\n",
@@ -724,7 +726,7 @@
     "    \n",
     "    # Lightly postprocess 'em\n",
     "    if headlines:\n",
-    "        headlines = [headline.strip() for headline in headlines if headline]\n",
+    "        headlines = [headline.replace(\"\\n\",\"\").strip() for headline in headlines if headline]\n",
     "        if max_headlines:\n",
     "            headlines = headlines[0:max_headlines]\n",
     "    return headlines"


### PR DESCRIPTION
Handles headline results in the format of "SUBHEAD\nHEADLINE", where the subhead is the name of an ongoing topic and headline is more specific -- often too specific to make sense without the subhead.