### PR TITLE
Add option to customize BeautifulSoup parser

### DIFF
--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -645,7 +645,7 @@
     "    \n",
     "    \"\"\"\n",
     "    response = requests.get(source[\"url\"])\n",
-    "    soup = BeautifulSoup(response.text, \"html.parser\")\n",
+    "    soup = BeautifulSoup(response.text, features=source.get(\"parser\", \"html.parser\"))\n",
     "    if \"select_query\" in source:\n",
     "        headlines = soup.select(source[\"select_query\"])\n",
     "        headlines = [headline.contents[0] for headline in headlines]\n",


### PR DESCRIPTION
For sources that work better with `lxml` instead of `html.parser`, for example