### PR TITLE
Move alert preface out of hyperlink

### DIFF
--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -1441,7 +1441,7 @@
     "        alerts = research_headlines(source, source.get(\"max_headlines\", None))\n",
     "        preface = source.get(\"alert_preface\", \"\")\n",
     "        return [\n",
-    "            f\"\"\"<a href=\"{source['url']}\" target=\"_blank\">{preface} {alert}</a>\"\"\" \n",
+    "            f\"\"\"{preface} <a href=\"{source['url']}\" target=\"_blank\">{alert}</a>\"\"\" \n",
     "            for alert in alerts\n",
     "        ] # Wrap the alert in a URL\n",
     "    elif source[\"type\"] == \"events_calendar\":\n",


### PR DESCRIPTION
Changes alert notifications from
```html
<a>New post found! Post name</a>
```
to 
```html
New post found! <a>Post name</a>
```
