### PR TITLE
Streamline log

### DIFF
--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -39,7 +39,9 @@
    "source": [
     "DEV_MODE = False # True will not send email and not cache newly fetched headlines for dedup later\n",
     "DISABLE_GPT = False # True will not call GPT API, so we don't incur costs while debugging\n",
-    "LOGGING_LEVEL = \"warning\" # Logs end up in admin's news email. Use \"warning\" by default. Change to \"info\" to get more detailed logs for debugging"
+    "LOGGING_LEVEL = \"info\" # What level of loggin should go in admin's issue?\n",
+    "                       # Use \"warning\" by default. Use \"info\" to get more detailed logs for debugging\n",
+    "                       # Reminder: When re-running notebook, to change logging level for example, restart kernel. Logger can only initialize once"
    ]
   },
   {

--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -336,7 +336,7 @@
     "        filtered_sources = []\n",
     "    else:\n",
     "        filtered_sources = [source for source in sources if source[criterion] in selections]\n",
-    "    logging.info(f\"Filtered out sources not in {selections}: {[source for source in sources if source[criterion] not in selections]}\")\n",
+    "    logging.info(f\"Filtered out sources not in {selections}: {[source['name'] for source in sources if source[criterion] not in selections]}\")\n",
     "    return filtered_sources\n",
     "\n",
     "\n",


### PR DESCRIPTION
Removes unnecessary information from `info` logging level