### PR TITLE
Change default frequency when events has no frequency configured

### DIFF
--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -438,7 +438,7 @@
     "    try:\n",
     "        subscriber_events_sources = subscriber_sources.get(\"events\", {}).get(\"sources\", [])\n",
     "        frequency_match = parse_frequency_config(\n",
-    "            subscriber_sources.get(\"events\", {}).get(\"frequency\", None)\n",
+    "            subscriber_sources.get(\"events\", {}).get(\"frequency\", {\"frequency\":\"daily\"})\n",
     "        )\n",
     "        if frequency_match and len(publication_events_sources)>0 and len(subscriber_events_sources)>0:\n",
     "            return filter_sources(publication_events_sources, subscriber_events_sources)\n",


### PR DESCRIPTION
This change turns off an unnecessary warning in admin email