### PR TITLE
Add r token removal to string cleaning

### DIFF
--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -710,7 +710,7 @@
     "    precleaning = True\n",
     "    while precleaning:\n",
     "        original_len = sum([len(h) for h in items])\n",
-    "        items = [h.strip(\"\\n\").strip(\"\\t\") for h in items]\n",
+    "        items = [h.strip(\"\\r\").strip(\"\\n\").strip(\"\\t\") for h in items]\n",
     "        precleaning = (original_len != sum([len(h) for h in items]))\n",
     "    \n",
     "    # Clean strings with a \"\\n\" in the middle\n",


### PR DESCRIPTION
Removes "\r" carriage returns from headlines