### PR TITLE
Fix scheduled job

### DIFF
--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -53,6 +53,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "96e3404b-21fc-4f9a-a41a-5ca2a731daca",
+   "metadata": {},
+   "source": [
+    "The next cell installs specific versions of packages that I've found play nice together on SageMaker, both local runs and scheduled jobs using `Python 3.8.13` on an `ml.m5.large` instance.  \n",
+    "  \n",
+    "ℹ️ If you're running FiniteNews in a different environment and you get errors here:\n",
+    "1. Try finding different versions that play nicely in your environment. Start by `pip` installing offending packages without a pinned version number and see which versions `pip` found.\n",
+    "2. If you're still getting errors on `sentence-transformers` (or its dependencies like `pytorch` or `GLIBCXX`), try a different environment. For example it may help to use the SageMaker image for `Pytorch 1.12 Python 3.8`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8175d1b-1bf3-4edf-993e-1f38d5826c8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --quiet beautifulsoup4==4.12.2 boto3==1.33.9 botocore==1.33.9 env_canada==0.6.1  \\\n",
+    "feedparser==6.0.11 ipywidgets==7.6.5 jupyterlab_widgets==1.0.0 matplotlib==3.4.3 openai==0.27.7 \\\n",
+    "pandas==1.3.4 s3fs==2024.2.0 seaborn==0.11.2 sendgrid==6.10.0 sentence-transformers==2.3.1 \\\n",
+    "widgetsnbextension==3.5.1 yfinance==0.2.33"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "0445b477-a51e-494f-8ed6-733a95c3637f",
@@ -61,9 +86,6 @@
    },
    "outputs": [],
    "source": [
-    "%pip install --quiet beautifulsoup4==4.12.2 boto3==1.33.9 botocore==1.33.9 env_canada==0.6.1 \\\n",
-    "feedparser==6.0.11 matplotlib==3.4.3 openai==0.27.7 pandas==1.3.4 s3fs==2024.2.0 seaborn==0.11.2 \\\n",
-    "sendgrid==6.10.0 sentence-transformers==2.3.1 yfinance==0.2.33\n",
     "import asyncio\n",
     "import base64\n",
     "import boto3\n",
@@ -3019,7 +3041,7 @@
     "vcpuNum": 128
    }
   ],
-  "instance_type": "ml.t3.medium",
+  "instance_type": "ml.m5.large",
   "kernelspec": {
    "display_name": "Python 3 (Data Science 2.0)",
    "language": "python",

--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -1878,6 +1878,7 @@
     "            ) >= smart_dedup_config[\"threshold\"]\n",
     "        ]\n",
     "        if not dups_found:\n",
+    "            logging.warning(f\"Smart deduper: no semantic dups found\")\n",
     "            return headlines\n",
     "\n",
     "        # Second, apply the transitive property of headline similarity! :D\n",


### PR DESCRIPTION
Makes the smart deduper's dependencies work as a SageMaker scheduled job.

After [adding this feature](https://github.com/cparmet/finite-news/pull/51), it worked fine in live runs of the SageMaker notebook. But scheduled runs stopped working due to a `GLIBCXX` errors from the new `pytorch` dependency. This PR finds a happy place of image selection (`ml.m5.large`) and package specifications that work in both live and scheduled runs. 