### PR TITLE
Fix casing of exception

### DIFF
--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -700,7 +700,7 @@
     "    except requests.exceptions.SSLError as e:\n",
     "        logging.warning(f\"SSL error on {source['name']}, {source['url']}. {str(type(e))}, {str(e)}\")\n",
     "        return []\n",
-    "    except exception as e:\n",
+    "    except Exception as e:\n",
     "        logging.warning(f\"Requests error on {source['name']}, {source['url']}. {str(type(e))}, {str(e)}\")\n",
     "        return []\n",
     "\n",


### PR DESCRIPTION
Fixes casing in exception handling. It caused an issue to fail when a source request threw an exception.