### PR TITLE
Add temporary fix to NWS icon

### DIFF
--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -1123,6 +1123,7 @@
     "            \"icon_url\": result.get(\"icon\", None)\n",
     "        }\n",
     "        forecast[\"short\"] = forecast[\"short\"].capitalize() # Change from Title Case to Sentence case \n",
+    "        forecast[\"icon_url\"] = \"https://api.weather.gov\" + forecast[\"icon_url\"] if forecast[\"icon_url\"] else forecast[\"icon_url\"]\n",
     "        if \"location_name\" in nws_config:\n",
     "            forecast[\"short\"] += f\" in {nws_config['location_name']}\"\n",
     "        return forecast\n",


### PR DESCRIPTION
Fixes the icon url that comes back from the National Weather Service API. A 6/20/24 update changed the url to only the directory path, and I've read they plan to restore the full url at a later update.