### PR TITLE
Update intro message

### DIFF
--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Welcome to Finite News!\n",
-    "This notebook creates and emails issues of Finite News."
+    "This notebook creates and emails issues of Finite News. To facilitate simple scheduling of the notebook with Sagemaker, all the code lives inside the notebook. Papermill jobs cannot import local Python scripts. "
    ]
   },
   {
@@ -131,8 +131,7 @@
    "id": "daccdb53-a46c-40e0-a8d3-105856b027e9",
    "metadata": {},
    "source": [
-    "# Functions\n",
-    "To play nicely with Sagemaker scheduled notebooks (Papermill), all the code we need lives inside the notebook or is installed by the notebook. Papermill jobs cannot import local Python scripts."
+    "# Functions"
    ]
   },
   {


### PR DESCRIPTION
Moves a markdown message to the top of the notebook, to explain why there are no `.py` scripts