### PR TITLE
Undo temporary NWS icon workaround

### DIFF
--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -1122,7 +1122,6 @@
     "            \"icon_url\": result.get(\"icon\", None)\n",
     "        }\n",
     "        forecast[\"short\"] = forecast[\"short\"].capitalize() # Change from Title Case to Sentence case \n",
-    "        forecast[\"icon_url\"] = \"https://api.weather.gov\" + forecast[\"icon_url\"] if forecast[\"icon_url\"] else forecast[\"icon_url\"]\n",
     "        if \"location_name\" in nws_config:\n",
     "            forecast[\"short\"] += f\" in {nws_config['location_name']}\"\n",
     "        return forecast\n",


### PR DESCRIPTION
Restores original url to NWS weather icon, after NWS fixed a breaking change that was made in their last API update