### PR TITLE
Unpin matplotlib

### DIFF
--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -74,9 +74,9 @@
    "outputs": [],
    "source": [
     "%pip install --quiet beautifulsoup4==4.12.2 boto3==1.33.9 botocore==1.33.9 env_canada==0.6.1 emoji==2.12.1 \\\n",
-    "feedparser==6.0.11 ipywidgets==7.6.5 jupyterlab_widgets==1.0.0 matplotlib==3.8.4 openai==0.27.7 \\\n",
+    "feedparser==6.0.11 ipywidgets==7.6.5 jupyterlab_widgets==1.0.0 openai==0.27.7 \\\n",
     "pandas==1.3.4 s3fs==2024.2.0 seaborn==0.11.2 sendgrid==6.10.0 sentence-transformers==2.3.1 \\\n",
-    "widgetsnbextension==3.5.1 yfinance==0.2.33"
+    "widgetsnbextension==3.5.1 yfinance==0.2.33 matplotlib"
    ]
   },
   {


### PR DESCRIPTION
Lets `pip` find the best version of `matplotlib`. Pinning the version in the last PR led to resolution issues in an updated instance of SageMaker.