### PR TITLE
Pin pandas again

### DIFF
--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -78,7 +78,7 @@
     "\n",
     "%pip install --quiet beautifulsoup4==4.12.2 boto3==1.33.9 botocore==1.33.9 env_canada==0.6.1 emoji==2.12.1 \\\n",
     "feedparser==6.0.11 ipywidgets==7.6.5 jupyterlab_widgets==1.0.0 openai==0.27.7 \\\n",
-    "pandas s3fs==2024.2.0 seaborn==0.11.2 sendgrid==6.10.0 sentence-transformers==2.3.1 \\\n",
+    "pandas==1.3.4 s3fs==2024.2.0 seaborn==0.11.2 sendgrid==6.10.0 sentence-transformers==2.3.1 \\\n",
     "widgetsnbextension==3.5.1 yfinance==0.2.33 matplotlib \n",
     "\n",
     "# Local \n",


### PR DESCRIPTION
The last PR unpinned the Pandas version to make installs faster on the SM Data Science 4.0 image. But that free range version led to an exception in Pandas plotting. So we'll pin the version to 1.3.4 again and prefer the Data Science 2.0 image while doing development on SM. on SM Classic it defaults to 4.0, but in scheduled jobs it defaults to 2.0.