### PR TITLE
Pin tokenizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Finite News is set up to run as a scheduled job in AWS Sagemaker.
 8. (Optional) Create an API account on openai.com, to use GPT to filter headlines
     - Add your api key to your AWS Secrets Manager under `fn_secrets` as `OPENAI_API_KEY`
 9. Test the notebook `finite_news.ipynb` in Sagemaker.
-    - Select a `ml.m5.large` instance and Data Science 2.0 image with Python 3.8, or a Data Science 4.0 image with Python 3.11. 
+    - Select a `ml.m5.large` instance and Data Science 2.0 image with Python 3.8. 
         - Other settings may work too! But the "Data Science" (1.0) image may not. And getting it to run on other instances may require changing the code such as finding different package versions that are happy together in that environment.
     - In the Parameters cell, set `DEV_MODE = True` etc so no email is sent. It will write the day's issues to a file in the notebook directory instead.
     - Inspect the file.

--- a/finite_news.ipynb
+++ b/finite_news.ipynb
@@ -74,11 +74,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --upgrade pip\n",
-    "\n",
-    "%pip install --quiet beautifulsoup4==4.12.2 boto3==1.33.9 botocore==1.33.9 env_canada==0.6.1 emoji==2.12.1 \\\n",
+    "%pip install beautifulsoup4==4.12.2 boto3==1.33.9 botocore==1.33.9 env_canada==0.6.1 emoji==2.12.1 \\\n",
     "feedparser==6.0.11 ipywidgets==7.6.5 jupyterlab_widgets==1.0.0 openai==0.27.7 \\\n",
-    "pandas==1.3.4 s3fs==2024.2.0 seaborn==0.11.2 sendgrid==6.10.0 sentence-transformers==2.3.1 \\\n",
+    "pandas==1.3.4 s3fs==2024.2.0 seaborn==0.11.2 sendgrid==6.10.0 tokenizers==0.20.1 sentence-transformers==2.3.1 \\\n",
     "widgetsnbextension==3.5.1 yfinance==0.2.33 matplotlib \n",
     "\n",
     "# Local \n",


### PR DESCRIPTION
Pins the version of tokenizers as used by sentence-transformers to avoid a new fatal error during pip install 
> Cargo, the Rust package manager, is not installed or is not on PATH.

Also prefers the Data Science Image 2.0 in SageMaker (Python 3.8) over 4.0 (Python 3.11), as the pinned versions are tailored for the former, requiring more of an adventure for pip to resolve dependencies for the latter.
