### PR TITLE
Prevent static images from getting de-duped by cache

### DIFF
--- a/sample_files/publication_config.yml
+++ b/sample_files/publication_config.yml
@@ -276,3 +276,12 @@ image_sources:
         url: url
         img_tag: true
         img_tag_number: 2  # Which <img> tag on the page? 1 is first 
+    # We add an image to the issue from an img tag whose src url is always the same
+    # For example some sources upload a new .jpg each day to the same URL
+    -
+      name: name
+      category: category
+      type: static
+      frequency:
+        frequency: daily
+      static_message: '<h4>Section title</h4><img src="https://url/to.jpg" alt="Content for {{DATE}}">' # {{DATE}} is filled in dynamically by the code so that the Alt tag varies every day. Otherwise, today's content for this item (<h4> + <img>) would be  exactly the same every day. Then when we cache it, tomorrow's issue will pull it and de-dup against the cache, which leads it to get dropped. 

--- a/tasks/reporting.py
+++ b/tasks/reporting.py
@@ -324,7 +324,19 @@ def research_source(source, requests_timeout):
             return get_calendar_events(source, requests_timeout)
         if source["type"] == "static":
             if parse_frequency_config(source.get("frequency", None)):
-                return [source.get("static_message", None)]
+                static_message = source.get("static_message", None)
+                if static_message:
+                    # Throw in the date if requested, like in an img's alt text.
+                    # Because with content like an img that always has the same src url,
+                    # e.g. NOAA Aurora forecasts, the <img> content is the same every day.
+                    # When we dedup today's content by comparing to the cached version of yesterday,
+                    # the <img> content would get dropped from today's issue.
+                    # So, vary the alt text each day.
+                    # publication_config.yml can have {{DATE}} in the "static_message" key
+                    static_message = static_message.replace(
+                        "{{DATE}}", date.today().strftime("%m/%d/%Y")
+                    )
+                return [static_message]
             else:
                 return []
         if source["type"] == "mbta_alerts":


### PR DESCRIPTION
Fixes a bug with the new [static image source](https://github.com/cparmet/finite-news/pull/98), making it so alt text can vary each day, even if the image itself doesn't, to ensure the image isn't dropped during the daily de-dupe with yesterday's content.

## Details
These add images to the Finstagram section that are always available at the same URL (`src` attribute in the `<img>` tag). The image itself varies over time, but the URL is the same, like for websites that refresh the image but keep its name and path.

When each Finite News issue is created, we cache its content. Then tomorrow we check if any candidate content for the next issue was already in yesterday's issue. If so, we drop it. There's the rub: the static image's content (`<img src>`) is always the same, so after the first instance, it will always get de-duped thereafter.

This PR adds the option for `publication_config.yml` to add a "{{DATE}}" placeholder to the `static_message` text. For example:

```yml
    -
      name: my source
      category: my category
      type: static
      frequency:
        frequency: daily
      static_message: '<h4>Daily refreshing image</h4><img src="https://to/url/latest.jpg" alt="Content for {{DATE}}">'
```

The code will fill in {{DATE}} with today's date. This makes the content different each day, in its alt text, preventing it from getting dropped during the de-dupe with yesterday's content.