### PR TITLE
Lil fixes

### DIFF
--- a/tasks/editing.py
+++ b/tasks/editing.py
@@ -25,7 +25,7 @@ def dedup(li):
     return [x for x in li if not (x in seen or seen.add(x))]
 
 
-def heal_inner_n(s):
+def heal_inner_n(s, heal_2nd_plus_with_ellipses=False):
     """Replace one or more inner \n with a colon.
 
     NOTES
@@ -33,12 +33,19 @@ def heal_inner_n(s):
 
     ARGUMENTS
     s (str): A string with or without one or more \n in the middle
+    heal_2nd_plus_with_ellipses (bool): If True, and there are more than one \n, replace the second \n and beyond with "..."
 
     RETURNS
     string with any \n in the middle replaced with a ": "
     """
 
     if "\n" in s:
+        if s.count("\n") > 1 and heal_2nd_plus_with_ellipses:
+            return (
+                s.split("\n")[0] + ": " + "...".join(s.split("\n")[1:])
+                # " -- ".join(s.split("\n")[1:]
+                # )
+            )
         return s.split("\n")[0] + ": " + s.split("\n")[-1]
     return s
 
@@ -114,7 +121,15 @@ def postprocess_scraped_content(items, source):
 
         # Clean strings with a "\n" in the middle
         if "heal_inner_n" in source:
-            items = [heal_inner_n(item) for item in items]
+            items = [
+                heal_inner_n(
+                    s=item,
+                    heal_2nd_plus_with_ellipses=source.get(
+                        "heal_2nd_plus_with_ellipses", False
+                    ),
+                )
+                for item in items
+            ]
 
         # Ensure each string is long enough.
         if "min_words" in source:

--- a/tasks/reporting.py
+++ b/tasks/reporting.py
@@ -675,7 +675,7 @@ def get_screenshots(sources, dev_mode=False):
             elements = driver.find_elements(criteria, value)
 
             # For some dynamically generated images, scraping them too quickly leads to incompelte screenshots
-            sleep(source.get("delay_secs_for_loading", 5))
+            sleep(source.get("delay_secs_for_loading", 0))
             # Select the ith element, if present
             if len(elements) >= source["element_number"]:
                 chart_element = elements[source["element_number"] - 1]

--- a/tasks/reporting.py
+++ b/tasks/reporting.py
@@ -513,8 +513,6 @@ def research_source(source, requests_timeout):
                 f"""{source.get('alert_preface', '')} <a href="{source['url']}" target="_blank"{alt_text}>{item}</a>"""
                 for item in items
             ]
-            # Populate any dynamic variables
-            items = [populate_variables(item) for item in items]
 
             return items
         else:

--- a/tasks/reporting.py
+++ b/tasks/reporting.py
@@ -335,14 +335,14 @@ def scrape_text_with_selenium(source, driver=None):
 
     except Exception as e:
         logging.warning(
-            f"Error [a] in scrape_text_with_selenium() on {source['url']}: {str(type(e))}, {str(e)}. source: {source}"
+            f"Error in scrape_text_with_selenium() on {source['url']}: {str(type(e))}, {str(e)}. source: {source}"
         )
         if quit_after_scrape:
             try:
                 driver.quit()
             except Exception as e:
                 logging.warning(
-                    f"Error [b] in scrape_text_with_selenium() on {source['url']}: {str(type(e))}, {str(e)}. source: {source}"
+                    f"Error while trying to quit driver in scrape_text_with_selenium() on {source['url']}: {str(type(e))}, {str(e)}. source: {source}"
                 )
                 return []
         return []


### PR DESCRIPTION
1. Change default Selenium delay on screenshots from 5 to 0 (none), so delay can be disabled
2. Clarify warning messages
3. Remove a redundant call to `populate_variables()`
4. Add option to replace some inner `\n` with ellipses "..."
  * Current behavior reformats "Preface\nHeadline" with "Preface: Headline"
  * But if scraped content has multiple `\n`s, everything in between first and second would be dropped. "Preface\nHeadline\nSubhead" became "Preface: Subhead"
  * With this option set, and if there are >1 inner `\n`s, it will become "Preface: Headline...Subhead". 
  * Notes:
     - These counts ignore `\n`s that appear on the ends of the scraped content, which are stripped out
     - I chose "..." instead of an em dash because the very first example I saw in this situation _also_ had em dashes in the subhead lol