### PR TITLE
Remove troublesome package from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && apt-get install -y \
     chromium-driver \
     libglib2.0-0 \
     libnss3 \
-    libgconf-2-4 \
     libfontconfig1 \
     libxcb1 \
     libx11-6 \


### PR DESCRIPTION
Removes `libgconf-2-4` from the image

GCP deployment was failing because `python:3.11-slim` no longer contains this package. And modern Chromium no longer needs it 🤘