### PR TITLE
Move 0 results check before postprocessing

### DIFF
--- a/tasks/reporting.py
+++ b/tasks/reporting.py
@@ -494,15 +494,18 @@ def research_source(source, requests_timeout):
                 body = ""
             items = [f"""{header}{img}{body}"""]
 
+        # Warn if no results were returned, if that was unexpected.
+        if len(items) == 0 and not source.get("exclude_from_0_results_warning", False):
+            logging.warning(
+                f"{source['name']}: retrieved 0 items before postprocessing. Source may be broken."
+            )
+            return []
+
         # Lightly postprocess results
         items = postprocess_scraped_content(items, source)
-
-        # Log count
-        if len(items) == 0 and not source.get("exclude_from_0_results_warning", False):
-            # Escalate to admin if no results were returned, and that was unexpected. Source's scraper/API may be broken.
-            logging.warning(f"{source['name']}: retrieved 0 items")
-        else:
-            logging.info(f"{source['name']}: retrieved {len(items)} items")
+        logging.info(
+            f"{source['name']}: retrieved {len(items)} items after postprocessing."
+        )
 
         # Add prefaces and return
         if source["type"] in ["headlines", "image_url"]:


### PR DESCRIPTION
Checks if a source returned 0 items before postprocessing. To reduce false alarm flags when items returned (source isn't broken) but none that met all criteria in the filters (must_contain etc).

Still applies `exclude_from_0_results_warning: True` for sources that are sparsely populated at all, but fewer sources need this condition anymore.