### PR TITLE
Progressively check for max events

### DIFF
--- a/tasks/events.py
+++ b/tasks/events.py
@@ -63,9 +63,11 @@ def extract_event_details(event_soup, calendar_config):
         "link_url_class" in calendar_config
         and "link_url_child_key" in "calendar_config"
     ):
-        event["link_url"] = event_soup.find(
-            class_=calendar_config["link_url_class"]
-        ).get(calendar_config["link_url_child_key"], "")
+        event["link_url"] = (
+            event_soup
+            .find(class_=calendar_config["link_url_class"])
+            .get(calendar_config["link_url_child_key"], "")
+        )  # fmt: skip
     else:
         event["link_url"] = ""
 
@@ -102,7 +104,7 @@ def scrape_calendar_page(calendar_config, url_base, page, requests_timeout=None)
         else:
             if not requests_timeout:
                 raise AttributeError(
-                    f"scrape_calendar_page: use_selenium is False, so we're using requests, but no value passed for requests_timeout (required). Full source: {calendar_config}"
+                    f"use_selenium is False, so we're using requests, but no value passed for requests_timeout (required). Full source: {calendar_config}"
                 )
             response = requests.get(url, timeout=requests_timeout)
             html_str = response.text

--- a/tasks/publishing.py
+++ b/tasks/publishing.py
@@ -328,10 +328,7 @@ def run_finite_news(dev_mode=True, disable_gpt=True):
     subscriber_configs = load_subscriber_configs(publication_config)
     smart_dedup_model = load_smart_dedup_model(
         publication_config["editorial"]
-        .get(
-            "smart_deduper",
-            {},
-        )
+        .get("smart_deduper", {})
         .get("path_to_model", None)
     )
 


### PR DESCRIPTION
Instead of truncating event list after scraping all calendar pages, check if we've breached `max_events` after scraping each page. 

This change also has a benefit that it prevents some web calendar configs from getting into to an endless loop, due to the last substantive page not shutting off scraping as it expected (more "events" keep being scraped from post-max page numbers, perhaps due to events in sidebars).